### PR TITLE
Update deckboard-discord

### DIFF
--- a/extensions/discord-deckboard.yml
+++ b/extensions/discord-deckboard.yml
@@ -1,7 +1,7 @@
 name: Discord Deckboard
 package: discord-deckboard
-version: 1.1.1
+version: 1.1.2
 description: A plugin to execute Discord actions from Deckboard
 author: Aislan Dener Souza Vicentini
 license: MIT
-repository: "https://github.com/osmancitci/discord-deckboard"
+repository: "https://github.com/aislandener/discord-deckboard"


### PR DESCRIPTION
Update Deckboard Discord

Remove copy paste discord access token
Because in ipc communication, don't send refreshToken to update. 