### PR TITLE
Update streamerbot-deckboard to v0.1.0

### DIFF
--- a/extensions/streamerbot-deckboard.yml
+++ b/extensions/streamerbot-deckboard.yml
@@ -1,6 +1,6 @@
 name: Streamer.bot Deckboard
 package: streamerbot-deckboard
-version: 0.0.1
+version: 0.1.0
 description: A plugin to execute Streamer.bot actions from Deckboard
 author: Riva Farabi
 license: MIT


### PR DESCRIPTION
Update streamerbot-deckboard to v0.1.0

Releases: https://github.com/rivafarabi/streamerbot-deckboard/releases/tag/0.1.0