### PR TITLE
Add CastMate Extension

### DIFF
--- a/extensions/castmate-deckboard.yml
+++ b/extensions/castmate-deckboard.yml
@@ -1,0 +1,7 @@
+name: CastMate
+package: castmate-deckboard
+version: 0.0.2
+description: Deckboard extension to trigger CastMate remotely
+author: LordTocs
+license: MIT
+repository: "https://github.com/LordTocs/CastMate-Deckboard"


### PR DESCRIPTION
CastMate is an open source streaming production/automation toolkit. This extension lets Deckboard buttons trigger CastMate v0.5+ remotely.